### PR TITLE
OSX Notification Center

### DIFF
--- a/regrowl/bridge/netcent.py
+++ b/regrowl/bridge/netcent.py
@@ -1,0 +1,66 @@
+"""
+Echo a growl to OSX NotificationCenter
+Created by heilerich (https://github.com/heilerich)
+
+Config Example:
+[regrowl.bridge.netcent]
+verbose = True
+"""
+
+from __future__ import absolute_import
+
+import logging
+import Foundation
+import objc
+import AppKit
+
+from regrowl.regrowler import ReGrowler
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['NetCenter']
+
+SPACER = '=' * 80
+
+
+class NetCenter(ReGrowler):
+    valid = ['REGISTER', 'NOTIFY']
+
+    def register(self, packet):
+        logger.info('Register')
+        print 'Registration Packet:'
+        if self.getboolean('verbose', False):
+            print SPACER
+            print packet
+            print SPACER
+        else:
+            print packet.headers['Application-Name']
+
+    def mlnc_notify(self, title, subtitle, text, url):
+        NSUserNotification = objc.lookUpClass('NSUserNotification')
+        NSUserNotificationCenter = objc.lookUpClass('NSUserNotificationCenter')
+        notification = NSUserNotification.alloc().init()
+        notification.setTitle_(str(title))
+        notification.setSubtitle_(str(subtitle))
+        notification.setInformativeText_(str(text))
+        notification.setSoundName_("NSUserNotificationDefaultSoundName")
+        notification.setHasActionButton_(True)
+        notification.setOtherButtonTitle_("View")
+        notification.setUserInfo_({"action":"open_url", "value":url})
+        NSUserNotificationCenter.defaultUserNotificationCenter().setDelegate_(self)
+        NSUserNotificationCenter.defaultUserNotificationCenter().scheduleNotification_(notification)
+
+    def notify(self, packet):
+        logger.info('Notify')
+        print 'Notification Packet:'
+        if self.getboolean('verbose', False):
+            print SPACER
+            print packet
+            print SPACER
+        else:
+            print packet.headers['Notification-Title'],
+            print packet.headers['Notification-Text']
+            if 'Notification-Callback-Target' in packet.headers:
+                self.mlnc_notify(packet.headers['Notification-Title'], "", packet.headers['Notification-Text'], packet.headers['Notification-Callback-Target'])
+            else:
+                self.mlnc_notify(packet.headers['Notification-Title'], "", packet.headers['Notification-Text'], "")

--- a/regrowl/bridge/netcent.py
+++ b/regrowl/bridge/netcent.py
@@ -36,13 +36,13 @@ class NetCenter(ReGrowler):
 
     def register(self, packet):
         logger.info('Register')
-        print 'Registration Packet:'
+        logger.info('Registration Packet:')
         if self.getboolean('verbose', False):
-            print SPACER
-            print packet
-            print SPACER
+            logger.info(SPACER)
+            logger.info(packet)
+            logger.info(SPACER)
         else:
-            print packet.headers['Application-Name']
+            logger.info(packet.headers['Application-Name'])
 
     def mlnc_notify(self, title, subtitle, text, url):
         NSUserNotification = objc.lookUpClass('NSUserNotification')
@@ -60,14 +60,14 @@ class NetCenter(ReGrowler):
 
     def notify(self, packet):
         logger.info('Notify')
-        print 'Notification Packet:'
+        logger.info('Notification Packet:')
         if self.getboolean('verbose', False):
-            print SPACER
-            print packet
-            print SPACER
+            logger.info(SPACER)
+            logger.info(packet)
+            logger.info(SPACER)
         else:
-            print packet.headers['Notification-Title'],
-            print packet.headers['Notification-Text']
+            logger.info(packet.headers['Notification-Title'])
+            logger.info(packet.headers['Notification-Text'])
             if 'Notification-Callback-Target' in packet.headers:
                 self.mlnc_notify(packet.headers['Notification-Title'], "", packet.headers['Notification-Text'], packet.headers['Notification-Callback-Target'])
             else:

--- a/regrowl/bridge/netcent.py
+++ b/regrowl/bridge/netcent.py
@@ -1,6 +1,7 @@
 """
 Echo a growl to OSX NotificationCenter
 Created by heilerich (https://github.com/heilerich)
+Requires PyObjC, install with pip
 
 Config Example:
 [regrowl.bridge.netcent]
@@ -10,9 +11,13 @@ verbose = True
 from __future__ import absolute_import
 
 import logging
-import Foundation
-import objc
-import AppKit
+
+try:
+    import Foundation
+    import objc
+    import AppKit
+except ImportError:
+    raise ImportError('Requires PyObjC, install with pip')
 
 from regrowl.regrowler import ReGrowler
 
@@ -25,6 +30,9 @@ SPACER = '=' * 80
 
 class NetCenter(ReGrowler):
     valid = ['REGISTER', 'NOTIFY']
+
+    def instance(self, packet):
+        pass
 
     def register(self, packet):
         logger.info('Register')

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
             'local = regrowl.bridge.local:LocalNotifier',
             'subscribe = regrowl.bridge.subscribe:SubscribelNotifier',
             'udp = regrowl.bridge.udp:UDPNotifier',
+            'netcent = regrowl.bridge.netcent:NetCenter'
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ setup(
             'echo = regrowl.bridge.echo:EchoNotifier',
             'forward = regrowl.bridge.forward:ForwardNotifier',
             'local = regrowl.bridge.local:LocalNotifier',
+            'netcent = regrowl.bridge.netcent:NetCenter',
             'subscribe = regrowl.bridge.subscribe:SubscribelNotifier',
             'udp = regrowl.bridge.udp:UDPNotifier',
-            'netcent = regrowl.bridge.netcent:NetCenter'
         ]
     }
 )


### PR DESCRIPTION
Added a simple bridge that creates native OSX notifications using PyObjC (available from PyPi). With this you can receive gntp notifications on your Mac without installing Growl.
